### PR TITLE
Emit typescript sourceMap to allow for correctly placed breakpoints.

### DIFF
--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES6",
         "moduleResolution": "node",
         "strict": true,
+        "sourceMap": true,
         "paths": {
             "three/examples/jsm/libs/dat.gui.module": ["../../node_modules/@types/dat.gui"]
         }


### PR DESCRIPTION
This was needed for proper debugging within vscode.